### PR TITLE
Fix extraneous brace in startTimer

### DIFF
--- a/main.js
+++ b/main.js
@@ -127,8 +127,6 @@ function startTimer() {
         isWorkSession = true;                  // 切換為工作狀態
         remainingSeconds = workMin * 60;
       }
-
-      }
       sessionDuration = remainingSeconds;
       updateDisplay();
       isRunning = false;


### PR DESCRIPTION
## Summary
- remove extra closing brace in `startTimer`
- keep logic after the if/else block intact

## Testing
- `node -c main.js`